### PR TITLE
Added more features to the deptreepy frontend

### DIFF
--- a/src/cqp_tree/frontends/deptreepy/translator.py
+++ b/src/cqp_tree/frontends/deptreepy/translator.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List
 
 from pyparsing import ParseException, nestedExpr
 
@@ -51,6 +51,26 @@ def query_from_deptreepy(deptreepy: str) -> ct.Query:
                 tokens.append(ct.Token(fresh_id, pred))
                 return fresh_id
 
+    def operation_constructor_for_field(field) -> Callable[[str], ct.Operation]:
+        if not isinstance(field, str):
+            raise ct.NotSupported('When matching a field, the field must be a string.')
+
+        comparison_operator = '='
+        if field.endswith('_'):
+            field = field[:-1]
+            comparison_operator = 'contains'
+
+        def constructor(strpatt: str) -> ct.Operation:
+            if not isinstance(strpatt, str):
+                raise ct.NotSupported('When matching a field, the field value must be a string.')
+            return ct.Operation(
+                ct.Attribute(None, field),
+                comparison_operator,
+                ct.Literal(f'"{strpatt}"'),
+            )
+
+        return constructor
+
     def convert_predicate(lisp) -> ct.Predicate:
         match lisp:
             case [singleton]:
@@ -66,23 +86,11 @@ def query_from_deptreepy(deptreepy: str) -> ct.Query:
                 return ct.Negation(convert_predicate(args))
 
             case [field, 'IN', *strpatts]:
-                return ct.Disjunction(
-                    [
-                        ct.Operation(
-                            ct.Attribute(None, field),
-                            '=',
-                            ct.Literal(f'"{strpatt}"'),
-                        )
-                        for strpatt in strpatts
-                    ]
-                )
+                ctor = operation_constructor_for_field(field)
+                return ct.Disjunction([ctor(strpatt) for strpatt in strpatts])
 
             case [field, strpatt]:
-                return ct.Operation(
-                    ct.Attribute(None, field),
-                    '=',
-                    ct.Literal(f'"{strpatt}"'),
-                )
+                return operation_constructor_for_field(field)(strpatt)
 
             case args:
                 raise ct.NotSupported(str(args))

--- a/src/cqp_tree/frontends/deptreepy/translator.py
+++ b/src/cqp_tree/frontends/deptreepy/translator.py
@@ -33,6 +33,9 @@ def query_from_deptreepy(deptreepy: str) -> ct.Query:
 
     def convert(lisp) -> ct.Identifier:
         match lisp:
+            case ['TREE', *_]:
+                raise ct.NotSupported('Only TREE_ is supported for matching subtrees.')
+
             case [singleton]:
                 return convert(singleton)
 

--- a/tests/deptreepy/__init__.py
+++ b/tests/deptreepy/__init__.py
@@ -1,0 +1,4 @@
+import unittest
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/deptreepy/test_translator.py
+++ b/tests/deptreepy/test_translator.py
@@ -1,0 +1,85 @@
+import unittest
+
+from cqp_tree import Attribute, Disjunction, Literal, NotSupported, Operation
+from cqp_tree.frontends.deptreepy import query_from_deptreepy
+
+
+class TranslationTests(unittest.TestCase):
+
+    def test_tree_(self):
+        with self.assertRaises(NotSupported):
+            query_from_deptreepy('TREE a b c')
+
+    def test_tree(self):
+        q = query_from_deptreepy('TREE_ ((AND (POS NOUN) (DEPREL det))) (OR (LEMMA IN a b c)))')
+        self.assertIsNotNone(q)
+
+    def test_field_comparison(self):
+        q = query_from_deptreepy('field a')
+        (token,) = q.tokens
+
+        self.assertEqual(
+            token.attributes,
+            Operation(
+                Attribute(None, 'field'),
+                '=',
+                Literal('"a"'),
+            ),
+        )
+
+    def test_field_in_comparison(self):
+        q = query_from_deptreepy('field IN a b')
+        (token,) = q.tokens
+
+        self.assertEqual(
+            token.attributes,
+            Disjunction(
+                [
+                    Operation(
+                        Attribute(None, 'field'),
+                        '=',
+                        Literal('"a"'),
+                    ),
+                    Operation(
+                        Attribute(None, 'field'),
+                        '=',
+                        Literal('"b"'),
+                    ),
+                ]
+            ),
+        )
+
+    def test_field_contains_comparison(self):
+        q = query_from_deptreepy('field_ a')
+        (token,) = q.tokens
+
+        self.assertEqual(
+            token.attributes,
+            Operation(
+                Attribute(None, 'field'),
+                'contains',
+                Literal('"a"'),
+            ),
+        )
+
+    def test_field_in_contains_comparison(self):
+        q = query_from_deptreepy('field_ IN a b')
+        (token,) = q.tokens
+
+        self.assertEqual(
+            token.attributes,
+            Disjunction(
+                [
+                    Operation(
+                        Attribute(None, 'field'),
+                        'contains',
+                        Literal('"a"'),
+                    ),
+                    Operation(
+                        Attribute(None, 'field'),
+                        'contains',
+                        Literal('"b"'),
+                    ),
+                ]
+            ),
+        )


### PR DESCRIPTION
The deptreepy frontend now supports `_`-queries! That is, we simulate queries like `(FEATS_ SpaceAfter=Yes)` by extending field checks. If a field ends with an underscore, we check whether the string-pattern afterwards is **contained in** the field value, instead of **being equal to** the string value. This works for all fields.

Also, there are now some checks to report errors:
- fields must be a string
- string-patterns must be a string
- searching for TREE reports an error, instead of trying to query a token with a field named TREE.