### PR TITLE
Initial support for CoNLL-U like constructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently, the following other query-languages are (partially) supported:
 1. [Grew-match](https://match.grew.fr/)
 2. [deptreepy](https://github.com/aarneranta/deptreepy/tree/main)
 3. [CoNLL-U](https://universaldependencies.org/format.html): this is not commonly intended as a query language, but (partial) trees in CoNLL-U format can be interpreted as queries. For details, see [conll_frontend.md](conll_frontend.md)
+4. [conlluc](https://github.com/LaboratorioSperimentale/adoc), a data format for UD-like constructions as defined by the ItCon project (experimental; support is very partial)
 
 In order to translate a query, you can provide it either via the command line, as the contents of a file or by directly typing it out into the program:
 

--- a/resources/example.conlluc
+++ b/resources/example.conlluc
@@ -1,0 +1,10 @@
+# cxn_id = 68
+# name = salta fuori che V
+# function = ref:D is found out unexpectedly
+# horizontal_links = 167
+# vertical_links =
+# fields = ID UD.FORM LEMMA UPOS FEATS HEAD DEPREL REQUIRED WITHOUT SEM_FEATS SEM_ROLES ADJACENCY IDENTITY
+A	_	saltare	VERB	Number=Sing|Person=3	0	root	1	CHILDREN:DEPREL=nsubj	_	_	_	_
+B	fuori	fuori	ADV	_	A	advmod	1	_	_	_	A	_
+C	che	che	SCONJ	_	D	mark	1	_	_	_	_	_
+D	_	_	VERB,NOUN,ADJ	VerbForm=Fin	A	csubj	1	_	_	Eventuality	_	_

--- a/src/cqp_tree/frontends/conlluc/__init__.py
+++ b/src/cqp_tree/frontends/conlluc/__init__.py
@@ -1,1 +1,1 @@
-from .translator import query_from_conll
+from .translator import query_from_conlluc

--- a/src/cqp_tree/frontends/conlluc/__init__.py
+++ b/src/cqp_tree/frontends/conlluc/__init__.py
@@ -1,0 +1,1 @@
+from .translator import query_from_conll

--- a/src/cqp_tree/frontends/conlluc/tools.py
+++ b/src/cqp_tree/frontends/conlluc/tools.py
@@ -1,0 +1,50 @@
+# fetched from https://raw.githubusercontent.com/LaboratorioSperimentale/adoc/refs/heads/main/src/tools.py
+# TODO: curl
+
+
+def parse_token(cols):
+	header = ["id", "form", "lemma", "upos", "feats", "head", "deprel", "required", "without", "sem_feats", "sem_roles", "adjacency", "identity"]
+
+	ret = {}
+	for x, y in zip(header, cols):
+		if x in ["id", "feats"]:
+			ret[x]=y
+		elif x in ["form", "lemma", "upos"]:
+			ret[x] = y.split(",")
+		elif x in ["required"]:
+			ret[x]=bool(int(y))
+		else:
+			ret[x]=y
+
+	return ret
+
+
+
+# TODO: handle more than one construction
+def parse(construction_str, mapping=None):
+
+	construction = construction_str.split("\n")
+
+	ret = { "metadata": [],
+			"tokens": []
+		}
+
+	for line in construction:
+		line = line.strip()
+		if len(line):
+			if line.startswith("#"):
+				ret["metadata"].append(line[1:].split("="))
+			else:
+				new_token = parse_token(line.split("\t"))
+				ret["tokens"].append(new_token)
+
+	return ret
+
+
+if __name__ == "__main__":
+	with open("/Users/ludovica/Documents/projects/adoc/cxns_conllc/cxn_68.conllc") as fin:
+		res = parse(fin.read())
+
+		print(res["metadata"])
+		for tok in res["tokens"]:
+			print(tok)

--- a/src/cqp_tree/frontends/conlluc/translator.py
+++ b/src/cqp_tree/frontends/conlluc/translator.py
@@ -1,0 +1,63 @@
+from typing import List
+
+import conllu
+
+import cqp_tree.translation as ct
+
+# CoNLL-U fields mapped to Språkbanken Korp attributes
+FIELDS2ATTRS = {
+    "form": "word",
+    "lemma": "lemma",
+    "upos": "pos",  # but upos (actual UD tags) may be added soon
+    "xpos": "msd",  # not sure about this one
+    "feats": "ufeats",  # actual UD features
+    "deprel": "deprel",  # mambadep, but UD relations may be added soon
+    # id and head are not treated as attributes
+    # deps and misc are ignored for the time being
+}
+
+
+def parse(s: str):
+    try:
+        parsed = conllu.parse(s)
+    except conllu.exceptions.ParseException as ex:
+        raise ct.ParsingFailed(ct.InputError(None, ex))
+    return parsed[0]  # only first parsed CoNLL-U sentence
+
+
+@ct.translator('conll')
+def query_from_conll(conll: str) -> ct.Query:
+    tokens: List[ct.Token] = []
+    dependencies: List[ct.Dependency] = []
+
+    conll_lines = parse(conll)
+
+    ids = [ct.Identifier() for _ in conll_lines]
+
+    def field2op(field, value) -> ct.Comparison:
+        return ct.Comparison(ct.Attribute(None, field), '=', ct.Literal(f'"{value}"'))
+
+    def is_empty(line, field):
+        return line[field] in ["_", None]
+
+    for line, id in list(zip(conll_lines, ids)):
+        if not isinstance(line["id"], int):
+            continue  # skip MWE lines
+        if is_empty(line, "id") or is_empty(line, "head"):
+            raise ct.NotSupported("IDs and HEADs cannot be omitted.")
+        ops = []
+        # pylint: disable=consider-using-dict-items
+        for field in FIELDS2ATTRS:
+            if not is_empty(line, field):
+                ops.append(field2op(FIELDS2ATTRS[field], line[field]))
+        if ops:
+            tokens.append(ct.Token(id, ct.Conjunction(ops)))
+        else:  # token with no attributes, only there for structural reasons
+            tokens.append(ct.Token(id))
+
+        if line["head"] != 0:
+            dependencies.append(
+                ct.Dependency(ids[[line["id"] for line in conll_lines].index(line["head"])], id)
+            )
+
+    return ct.Query(tokens=tokens, dependencies=dependencies)


### PR DESCRIPTION
Initial support for the format used [here](https://github.com/LaboratorioSperimentale/adoc) (i.e. @ellepannitto's format).

The parser for this format is under development. It will be possible to fetch newer versions from [here](https://raw.githubusercontent.com/LaboratorioSperimentale/adoc/refs/heads/main/src/tools.py).

Support is currently very partial, missing:

- [ ] support for the `IDENTITY` column (format: `COLNAME=ID`), which is used to specify that a certain field of a given token is the same as a certain field of another token with id `ID`, e.g. "day by day", "year by year"... (as far as I understand, this is actually possible to do with the current backend)
- [ ] support for the `ADJACENCY` field, which is used to add order constraints (@Niklas-Deworetzki: am I right that this isn't supported by the backend yet?)
- [ ] possibility to underspecify dependency structures
- [ ] support for the `WITHOUT` field: this is the most challenging (at least when it comes to structural properties, e.g. `CHILDREN:DEPREL=advmod`) because it requires universal quantification, a bit like `TREE` in deptreepy
- [ ] support for the token `REQUIRED`, which, if set to 0, makes the token optional (not sure about this one).