### PR TITLE
Initial Sketch Engine support

### DIFF
--- a/src/cqp_tree/__init__.py
+++ b/src/cqp_tree/__init__.py
@@ -22,6 +22,13 @@ DEFAULT_CONFIGURATIONS = [
         readable_description='Active profile to which matched results are expanded.',
     ),
     DeclaredConfig(
+        key='dialect',
+        readable_name='CQP Dialect',
+        readable_description='The version of the Corpus Query Protocol language to use.',
+        validation_type=CQPDialect,
+        default_value=CQPDialect.CWB,
+    ),
+    DeclaredConfig(
         key='word',
         readable_name='Wordform annotation',
         readable_description='Name of the annotation layer encoding word forms.',

--- a/src/cqp_tree/translation/__init__.py
+++ b/src/cqp_tree/translation/__init__.py
@@ -1,4 +1,4 @@
-from cqp_tree.translation.cqp import format_plan, from_query as cqp_from_query
+from cqp_tree.translation.cqp import CQPDialect, format_plan, from_query as cqp_from_query
 from cqp_tree.translation.configurable import dependency_type_equals, wordform_equals
 from cqp_tree.translation.errors import InputError, ParsingFailed, NotSupported
 from cqp_tree.translation.query import (

--- a/src/cqp_tree/translation/backends/common.py
+++ b/src/cqp_tree/translation/backends/common.py
@@ -1,0 +1,355 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional, override
+
+from cqp_tree.configuration import Configuration
+from cqp_tree.translation import query
+from cqp_tree.utils import (
+    associate_with_names,
+    filter_is_instance,
+    flatmap_set,
+    to_str,
+)
+
+Environment = dict[query.Identifier, str]
+
+
+class Query(ABC):
+    """Abstract base class for all queries."""
+
+    target_identifier: Optional[query.Identifier]
+
+    @abstractmethod
+    def referenced_identifiers(self) -> set[query.Identifier]: ...
+
+    # This is bound in cqp.py after knowing all the backend formatters
+    def to_string(self, configuration: Configuration) -> str: ...
+
+
+@dataclass
+class GlobalConstraint(Query):
+    base: Query
+    # Initialize with empty set by default.
+    associated_predicates: set[query.Predicate] = field(default_factory=set)
+    associated_dependencies: set[query.Dependency] = field(default_factory=set)
+
+    @override
+    def referenced_identifiers(self) -> set[query.Identifier]:
+        identifiers = self.base.referenced_identifiers()
+        identifiers |= flatmap_set(
+            self.associated_dependencies,
+            lambda r: r.referenced_identifiers(),
+        )
+        identifiers |= flatmap_set(
+            self.associated_predicates,
+            lambda a: a.referenced_identifiers(),
+        )
+        return identifiers
+
+
+@dataclass
+class WithinConstraint(Query):
+    base: Query
+    span: str
+
+    def referenced_identifiers(self) -> set[query.Identifier]:
+        return self.base.referenced_identifiers()
+
+
+@dataclass
+class Sequence(Query):
+    """Class representing a sequence of queries."""
+
+    lhs: Query
+    rhs: Query
+    tokens_between: bool = True
+
+    @override
+    def referenced_identifiers(self) -> set[query.Identifier]:
+        return self.lhs.referenced_identifiers() | self.rhs.referenced_identifiers()
+
+
+@dataclass
+class Operator(Query):
+    """Class representing multiple queries joined by some operator (disjunction, for example)."""
+
+    operator: str
+    queries: list[Query]
+
+    @override
+    def referenced_identifiers(self) -> set[query.Identifier]:
+        return flatmap_set(self.queries, lambda q: q.referenced_identifiers())
+
+
+@dataclass
+class Token(Query):
+    """Class representing a query for a single token."""
+
+    identifier: query.Identifier
+    # Initialize with empty set by default.
+    associated_predicates: set[query.Predicate] = field(default_factory=set)
+    associated_dependencies: set[query.Dependency] = field(default_factory=set)
+
+    @override
+    def referenced_identifiers(self) -> set[query.Identifier]:
+        identifiers = flatmap_set(
+            self.associated_dependencies, lambda r: r.referenced_identifiers()
+        )
+        identifiers |= flatmap_set(self.associated_predicates, lambda a: a.referenced_identifiers())
+        identifiers -= {self.identifier}
+        return identifiers
+
+
+@dataclass
+class Span(Query):
+    """Class representing begin or end of a text span in the corpus."""
+
+    span: str
+    position: query.Position
+
+    @override
+    def referenced_identifiers(self) -> set[query.Identifier]:
+        return set()
+
+
+def add_within_and_anchors(
+    translated: Query,
+    original: query.Query,
+    configuration: Configuration,
+) -> Query:
+    if configuration.span:
+        span = configuration.span
+
+        anchors = list(filter_is_instance(original.constraints, query.Constraint.Anchor))
+        if anchors:
+            translated = add_anchors(translated, anchors, span)
+
+        translated = WithinConstraint(translated, span)
+    return translated
+
+
+def add_anchors(q: Query, anchors: Iterable[query.Constraint.Anchor], span: str) -> Query:
+    has_last = any(anchor.is_last() for anchor in anchors)
+    if has_last:
+        q = Sequence(q, Span(span, query.Position.LAST), tokens_between=False)
+
+    has_first = any(anchor.is_first() for anchor in anchors)
+    if has_first:
+        q = Sequence(Span(span, query.Position.FIRST), q, tokens_between=False)
+    return q
+
+
+def arrangements(
+    identifiers: set[query.Identifier],
+    constraints: Iterable[query.Constraint],
+) -> Iterable[list[query.Identifier]]:
+    """Arrange a set of Identifiers into all sequences allowed by the given Constraints"""
+    cannot_be_after = {i: set() for i in identifiers}
+    for constraint in constraints:
+        if isinstance(constraint, query.Constraint.Order):
+            fst, snd = constraint
+            cannot_be_after[snd].add(fst)
+        elif isinstance(constraint, query.Constraint.Anchor):
+            (id,) = constraint
+            other_identifiers = identifiers - set(id)
+            if constraint.is_first():  # id cannot be after any of the others
+                cannot_be_after[id].update(other_identifiers)
+            if constraint.is_last():  # No other cannot be after id.
+                for other in other_identifiers:
+                    cannot_be_after[other].add(id)
+
+    # Buffer with space for all identifiers.
+    arrangement: list[query.Identifier] = [None] * len(identifiers)
+
+    def arrange(index: int, remaining_identifiers: set[query.Identifier]):
+        if index == len(arrangement):
+            yield list(arrangement)  # Everything is put into an order. Yield it!
+        else:
+            for identifier in remaining_identifiers:
+                arrangement[index] = identifier
+
+                restricted = cannot_be_after[identifier]  # Continue for remaining identifiers.
+                yield from arrange(index + 1, (remaining_identifiers - restricted) - {identifier})
+
+    yield from arrange(0, identifiers)
+
+
+class QueryFormatter(ABC):
+    """
+    Abstract QueryFormatter superclass, handles the following common functionality:
+    1. Recursing on query components
+    2. Formatting of predicates, operands and dependencies
+    3. Proper parenthesis for subcomponents in Sequence and Operator
+
+    A concrete subclass has to implement a formatting function for each concrete query type.
+    """
+
+    configuration: Configuration
+    environment: Environment
+
+    def __init__(self, configuration: Configuration, q: Query):
+        self.configuration = configuration
+        self.environment = associate_with_names(q.referenced_identifiers(), self.names())
+
+    @classmethod
+    def to_str(cls, q: Query, configuration: Configuration) -> str:
+        return cls(configuration, q).format(q)
+
+    @staticmethod
+    def _parens_if(s: str, o: Any, cls: type | tuple) -> str:
+        return f'({s})' if isinstance(o, cls) else s
+
+    def format(self, q: query.Query) -> str:
+        print('f')
+        if isinstance(q, GlobalConstraint):
+            base_repr = self.format(q.base)
+            predicate_reprs = [self.format_predicate(p) for p in q.associated_predicates]
+            dependency_reprs = [
+                self.format_dependency(d.src, d.dst) for d in q.associated_dependencies
+            ]
+            return self.format_global_constraint(base_repr, predicate_reprs, dependency_reprs)
+
+        elif isinstance(q, WithinConstraint):
+            base_repr = self.format(q.base)
+            return self.format_within_constraint(base_repr, q.span)
+
+        elif isinstance(q, Span):
+            return self.format_span(q.span, q.position)
+
+        elif isinstance(q, Sequence):
+            lhs_repr = self.format(q.lhs)
+            rhs_repr = self.format(q.rhs)
+            lhs_repr = self._parens_if(lhs_repr, q.lhs, Operator)
+            rhs_repr = self._parens_if(rhs_repr, q.lhs, Operator)
+            return self.format_sequence(lhs_repr, rhs_repr, q.tokens_between)
+
+        elif isinstance(q, Operator):
+            parts = []
+            for q_ in q.queries:
+                part = self.format(q_)
+                part = self._parens_if(part, q_, (Token, Sequence))
+                parts.append(part)
+            return self.format_operator(q.operator, parts)
+
+        elif isinstance(q, Token):
+            predicates = []
+            for attribute in q.associated_predicates:
+                # Expand conjunction as all predicates on token are already conjunct.
+                if isinstance(attribute, query.Conjunction):
+                    predicates.extend(self.format_predicate(p) for p in attribute.predicates)
+                else:
+                    predicates.append(self.format_predicate(attribute))
+
+            dependencies = []
+            for dependency in q.associated_dependencies:
+                if dependency.src == q.identifier:
+                    part = self.format_dependency(dst=dependency.dst)
+                else:
+                    part = self.format_dependency(src=dependency.src)
+                dependencies.append(part)
+
+            return self.format_token(q.identifier, predicates, dependencies)
+
+        raise ValueError(f'Cannot format query of type {type(q).__name__}')
+
+    @classmethod
+    @abstractmethod
+    def names(cls) -> Iterable[str]: ...
+
+    @abstractmethod
+    def format_global_constraint(
+        self,
+        base: str,
+        predicates: list[str],
+        dependencies: list[str],
+    ) -> str: ...
+
+    @abstractmethod
+    def format_within_constraint(
+        self,
+        base: str,
+        span: str,
+    ) -> str: ...
+
+    @abstractmethod
+    def format_operator(
+        self,
+        operator: str,
+        queries: list[str],
+    ) -> str: ...
+
+    @abstractmethod
+    def format_token(
+        self,
+        identifier: query.Identifier,
+        predicates: list[str],
+        dependencies: list[str],
+    ) -> str: ...
+
+    @abstractmethod
+    def format_sequence(
+        self,
+        lhs: str,
+        rhs: str,
+        tokens_between: bool,
+    ) -> str: ...
+
+    @abstractmethod
+    def format_span(
+        self,
+        span: str,
+        position: query.Position,
+    ): ...
+
+    def format_dependency(
+        self,
+        src: Optional[query.Identifier] = None,
+        dst: Optional[query.Identifier] = None,
+    ) -> str:
+        dephead = self.configuration.dephead
+        ref = self.configuration.token_id
+
+        src = self.environment[src] if src is not None else None
+        dst = self.environment[dst] if dst is not None else None
+        match (src, dst):
+            case (None, None):
+                raise ValueError('Cannot format when `src´ and `dst´ are None')
+            case (src, None):
+                return f'{dephead} = {src}.{ref}'
+            case (None, dst):
+                return f'{dst}.{dephead} = {ref}'
+            case (src, dst):
+                return f'{dst}.{dephead} = {src}.{ref}'
+
+    def format_operand(self, operand: query.Operand) -> str:
+        if isinstance(operand, query.Attribute):
+            if operand.reference is not None:
+                return f'{self.environment[operand.reference]}.{operand.attribute}'
+            return operand.attribute
+        elif isinstance(operand, query.Reference):
+            if operand.reference is not None:
+                return self.environment[operand.reference]
+            return '_'
+        elif isinstance(operand, query.Function):
+            args = ', '.join(self.format_operand(arg) for arg in operand.args)
+            return f'{operand.name}({args})'
+        assert isinstance(operand, query.Literal), 'Operand must be either Attribute or Literal.'
+        return operand.value
+
+    def format_predicate(self, predicate: query.Predicate) -> str:
+        if isinstance(predicate, query.Exists):
+            return self.format_operand(predicate.attribute)
+        elif isinstance(predicate, query.Negation):
+            return f'!{self.format_predicate(predicate.predicate)}'
+        if isinstance(predicate, query.Comparison):
+            lhs = self.format_operand(predicate.lhs)
+            rhs = self.format_operand(predicate.rhs)
+            return f'({lhs} {predicate.operator} {rhs})'
+        else:
+            assert isinstance(predicate, (query.Conjunction, query.Disjunction))
+            operators = {
+                query.Conjunction: '&',
+                query.Disjunction: '|',
+            }
+            predicates = map(self.format_predicate, predicate.predicates)
+            return to_str(predicates, '(', f' {operators[type(predicate)]} ', ')')

--- a/src/cqp_tree/translation/backends/common.py
+++ b/src/cqp_tree/translation/backends/common.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Optional, override
+from typing import Any, Iterable, Optional, overload, override
 
 from cqp_tree.configuration import Configuration
 from cqp_tree.translation import query
@@ -23,6 +23,7 @@ class Query(ABC):
     def referenced_identifiers(self) -> set[query.Identifier]: ...
 
     # This is bound in cqp.py after knowing all the backend formatters
+    @overload
     def to_string(self, configuration: Configuration) -> str: ...
 
 
@@ -271,35 +272,24 @@ class QueryFormatter(ABC):
         span: str,
     ) -> str: ...
 
-    @abstractmethod
-    def format_operator(
-        self,
-        operator: str,
-        queries: list[str],
-    ) -> str: ...
+    def format_operator(self, operator: str, queries: list[str]) -> str:
+        return f' {operator} '.join(queries)
 
-    @abstractmethod
     def format_token(
-        self,
-        identifier: query.Identifier,
-        predicates: list[str],
-        dependencies: list[str],
-    ) -> str: ...
+        self, identifier: query.Identifier, predicates: list[str], dependencies: list[str]
+    ) -> str:
+        prefix = self.environment[identifier] + ':' if identifier in self.environment else ''
+        predicate = ' & '.join(predicates + dependencies)
+        return f'{prefix}[{predicate}]'
 
-    @abstractmethod
-    def format_sequence(
-        self,
-        lhs: str,
-        rhs: str,
-        tokens_between: bool,
-    ) -> str: ...
+    def format_sequence(self, lhs: str, rhs: str, tokens_between: bool) -> str:
+        if tokens_between:
+            return f'{lhs} []* {rhs}'
+        else:
+            return f'{lhs} {rhs}'
 
-    @abstractmethod
-    def format_span(
-        self,
-        span: str,
-        position: query.Position,
-    ): ...
+    def format_span(self, span: str, position: query.Position):
+        return f'<{span}>' if position == query.Position.FIRST else f'</{span}>'
 
     def format_dependency(
         self,

--- a/src/cqp_tree/translation/backends/cwb.py
+++ b/src/cqp_tree/translation/backends/cwb.py
@@ -1,0 +1,130 @@
+from functools import reduce
+
+from cqp_tree.translation.backends.common import *
+from cqp_tree.utils import LOWERCASE_ALPHABET, partition_set
+
+TOKEN_ALPHABET = LOWERCASE_ALPHABET
+
+
+def from_arrangement(
+    arrangement: list[query.Identifier],
+    dependencies: set[query.Dependency],
+    predicates: set[query.Predicate],
+) -> Query:
+    """Build a CWB Query for a sequence of Identifiers."""
+    visited_tokens: set[query.Identifier] = set()
+    remaining_dependencies = dependencies
+    remaining_predicates = predicates
+
+    converted_tokens = [Token(i) for i in arrangement]
+    for token in converted_tokens:
+        visited_tokens.add(token.identifier)
+
+        committable_dependencies, remaining_dependencies = partition_set(
+            remaining_dependencies,
+            lambda rel: rel.referenced_identifiers().issubset(visited_tokens),
+        )
+        committable_predicates, remaining_predicates = partition_set(
+            remaining_predicates,
+            lambda pred: pred.referenced_identifiers().issubset(visited_tokens),
+        )
+
+        token.associated_dependencies.update(committable_dependencies)
+        token.associated_predicates.update(  # Lower predicates when associating with token.
+            p.lower_onto(token.identifier) for p in committable_predicates
+        )
+
+    # Build all tokens into a sequence.
+    return reduce(Sequence, converted_tokens)
+
+
+def from_all_arrangements(
+    identifiers: set[query.Identifier],
+    dependencies: set[query.Dependency],
+    constraints: set[query.Constraint],
+    predicates: set[query.Predicate],
+) -> Query:
+    """Build a query over all sequences of Identifiers."""
+    all_arrangements = [
+        from_arrangement(arrangement, dependencies, predicates)
+        for arrangement in arrangements(identifiers, constraints)
+    ]
+    return Operator('|', all_arrangements)
+
+
+ORDER_TO_OPERATOR = {
+    query.Compare.EQ: '=',
+    query.Compare.NE: '!=',
+    query.Compare.LT: '<',
+    query.Compare.GT: '>',
+}
+
+
+def distance_to_operand(constraint: query.Constraint.Distance) -> query.Predicate:
+    fst, snd = constraint
+    dist_function = query.Function(
+        'distabs',
+        query.Reference(fst),
+        query.Reference(snd),
+    )
+    distance_literal = query.Literal(str(constraint.distance))
+    return query.Comparison(dist_function, ORDER_TO_OPERATOR[constraint.order], distance_literal)
+
+
+def cwb_from_query(q: query.Query, configuration: Configuration) -> Query:
+    """Translate a tree-based query into a CQP query for all different arrangements of tokens."""
+
+    predicates = set(pred.normalize() for pred in q.predicates)
+    for constraint in q.constraints:
+        if isinstance(constraint, query.Constraint.Distance):
+            predicates.add(distance_to_operand(constraint))
+
+    for token in q.tokens:  # Raise local predicates to prepare re-ordering.
+        if token.attributes is not None:
+            raised_predicate = token.attributes.raise_from(token.identifier)
+            raised_predicate = raised_predicate.normalize()
+            predicates.add(raised_predicate)
+
+    result = from_all_arrangements(
+        {token.identifier for token in q.tokens},
+        set(q.dependencies),
+        set(q.constraints),
+        predicates,
+    )
+
+    return add_within_and_anchors(result, q, configuration)
+
+
+class CwbFormatter(QueryFormatter):
+
+    @classmethod
+    def names(cls) -> Iterable[str]:
+        return TOKEN_ALPHABET
+
+    def format_global_constraint(
+        self, base: str, predicates: list[str], dependencies: list[str]
+    ) -> str:
+        constraint_repr = ' & '.join(predicates + dependencies)
+        return f'{base} :: {constraint_repr}'
+
+    def format_within_constraint(self, base: str, span: str) -> str:
+        return f'{base} within {span}'
+
+    def format_operator(self, operator: str, queries: list[str]) -> str:
+        return f' {operator} '.join(queries)
+
+    def format_token(
+        self, identifier: query.Identifier, predicates: list[str], dependencies: list[str]
+    ) -> str:
+        prefix = self.environment[identifier] + ':' if identifier in self.environment else ''
+        predicate = ' & '.join(predicates)
+        return f'{prefix}[{predicate}]'
+
+    def format_sequence(self, lhs: str, rhs: str, tokens_between: bool) -> str:
+        if tokens_between:
+            return f'{lhs} []* {rhs}'
+        else:
+            return f'{lhs} {rhs}'
+
+    def format_span(self, span: str, position: query.Position):
+        return f'<{span}>' if position == query.Position.FIRST else f'</{span}>'

--- a/src/cqp_tree/translation/backends/cwb.py
+++ b/src/cqp_tree/translation/backends/cwb.py
@@ -1,6 +1,17 @@
 from functools import reduce
+from typing import Iterable, override
 
-from cqp_tree.translation.backends.common import *
+from cqp_tree.translation.backends.common import (
+    Configuration,
+    Operator,
+    Query,
+    QueryFormatter,
+    Sequence,
+    Token,
+    add_within_and_anchors,
+    arrangements,
+    query,
+)
 from cqp_tree.utils import LOWERCASE_ALPHABET, partition_set
 
 TOKEN_ALPHABET = LOWERCASE_ALPHABET
@@ -101,30 +112,13 @@ class CwbFormatter(QueryFormatter):
     def names(cls) -> Iterable[str]:
         return TOKEN_ALPHABET
 
+    @override
     def format_global_constraint(
         self, base: str, predicates: list[str], dependencies: list[str]
     ) -> str:
         constraint_repr = ' & '.join(predicates + dependencies)
         return f'{base} :: {constraint_repr}'
 
+    @override
     def format_within_constraint(self, base: str, span: str) -> str:
         return f'{base} within {span}'
-
-    def format_operator(self, operator: str, queries: list[str]) -> str:
-        return f' {operator} '.join(queries)
-
-    def format_token(
-        self, identifier: query.Identifier, predicates: list[str], dependencies: list[str]
-    ) -> str:
-        prefix = self.environment[identifier] + ':' if identifier in self.environment else ''
-        predicate = ' & '.join(predicates)
-        return f'{prefix}[{predicate}]'
-
-    def format_sequence(self, lhs: str, rhs: str, tokens_between: bool) -> str:
-        if tokens_between:
-            return f'{lhs} []* {rhs}'
-        else:
-            return f'{lhs} {rhs}'
-
-    def format_span(self, span: str, position: query.Position):
-        return f'<{span}>' if position == query.Position.FIRST else f'</{span}>'

--- a/src/cqp_tree/translation/backends/sketch_engine.py
+++ b/src/cqp_tree/translation/backends/sketch_engine.py
@@ -1,6 +1,18 @@
 from functools import reduce
+from typing import Iterable, Optional, override
 
-from cqp_tree.translation.backends.common import *
+from cqp_tree.translation.backends.common import (
+    Configuration,
+    GlobalConstraint,
+    Operator,
+    Query,
+    QueryFormatter,
+    Sequence,
+    Token,
+    add_within_and_anchors,
+    arrangements,
+    query,
+)
 from cqp_tree.translation.errors import NotSupported
 
 # manatee does weird things when "0" is included as an identifier.
@@ -93,37 +105,20 @@ def sketchengine_from_query(q: query.Query, configuration: Configuration) -> Que
 
     return add_within_and_anchors(result, q, configuration)
 
+
 class SketchEngineFormatter(QueryFormatter):
 
     @classmethod
     def names(cls) -> Iterable[str]:
         return TOKEN_ALPHABET
 
+    @override
     def format_global_constraint(
         self, base: str, predicates: list[str], dependencies: list[str]
     ) -> str:
         constraint_repr = ' & '.join(predicates + dependencies)
         return f'({base}) & ({constraint_repr})'
 
+    @override
     def format_within_constraint(self, base: str, span: str) -> str:
         return f'{base} within <{span}/>'
-
-    def format_operator(self, operator: str, queries: list[str]) -> str:
-        return f' {operator} '.join(queries)
-
-    def format_token(
-        self, identifier: query.Identifier, predicates: list[str], dependencies: list[str]
-    ) -> str:
-        prefix = self.environment[identifier] + ':' if identifier in self.environment else ''
-        predicate = ' & '.join(predicates)
-        return f'{prefix}[{predicate}]'
-
-    def format_sequence(self, lhs: str, rhs: str, tokens_between: bool) -> str:
-        if tokens_between:
-            return f'{lhs} []* {rhs}'
-        else:
-            return f'{lhs} {rhs}'
-
-    def format_span(self, span: str, position: query.Position):
-        return f'<{span}>' if position == query.Position.FIRST else f'</{span}>'
-

--- a/src/cqp_tree/translation/backends/sketch_engine.py
+++ b/src/cqp_tree/translation/backends/sketch_engine.py
@@ -1,0 +1,129 @@
+from functools import reduce
+
+from cqp_tree.translation.backends.common import *
+from cqp_tree.translation.errors import NotSupported
+
+# manatee does weird things when "0" is included as an identifier.
+# The identifier appears to not be resolved properly.
+TOKEN_ALPHABET = list(map(str, range(1, 10)))
+
+
+def where_to_place_predicate(predicate: query.Predicate) -> Optional[query.Identifier]:
+    """
+    Manatee has strong opinions about how CQP should look like. We use an excerpt from the grammar
+    obtained here: https://corpora.fi.muni.cz/noske/current/src/manatee-open-2.225.8.tar.gz
+
+    Expressions for global constraints and within tokens are inductively defined over conjunction,
+    disjunction, negation and parentheses:
+
+    globalExpr ::=
+    | NUMBER DOT ATTRIBUTE EQ NUMBER DOT ATTRIBUTE
+    | NUMBER DOT ATTRIBUTE NEQ NUMBER DOT ATTRIBUTE
+
+    tokenAtom ::=
+    | ATTRIBUTE EQ REGEXP
+    | ATTRIBUTE NEQ REGEXP
+
+    So we need to disect, where to put a predicate. And maybe we can't even place it.
+    """
+    match predicate:
+        case query.Comparison(lhs=query.Attribute(reference=reference), rhs=query.Literal()):
+            return reference
+
+        case query.Comparison(lhs=query.Attribute(), rhs=query.Attribute()):
+            return None
+
+        case query.Negation():
+            return where_to_place_predicate(predicate.predicate)
+
+        case query.GenericJunction():
+            unique_places = {where_to_place_predicate(p) for p in predicate.predicates}
+            if len(unique_places) == 1:
+                return next(iter(unique_places))
+
+    raise NotSupported('SketchEngine does not support the way token attributes are compared.')
+
+
+def collect_predicates(q: query.Query) -> set[query.Predicate]:
+    predicates = set()
+    predicates.update(q.predicates)
+    for t in q.tokens:
+        if t.attributes is not None:
+            predicates.add(t.attributes.raise_from(t.identifier))
+    return predicates
+
+
+def associate_predicates(
+    q: query.Query,
+) -> tuple[dict[query.Identifier, Token], set[query.Predicate]]:
+    # Collect all the predicates
+    predicates = collect_predicates(q)
+
+    # Decide where to put the predicates
+    global_predicates = set()
+    per_token_predicates = {token.identifier: set() for token in q.tokens}
+    for predicate in predicates:
+        if where := where_to_place_predicate(predicate):
+            per_token_predicates[where].add(predicate)
+        else:
+            global_predicates.add(predicate)
+
+    # Now build tokens with the predicates
+    tokens: dict[query.Identifier, Token] = {}
+    for token_id, predicates in per_token_predicates.items():
+        lowered_predicates = {predicate.lower_onto(token_id) for predicate in predicates}
+        tokens[token_id] = Token(token_id, lowered_predicates)
+    return tokens, predicates
+
+
+def sketchengine_from_query(q: query.Query, configuration: Configuration) -> Query:
+    for constraint in q.constraints:
+        if isinstance(constraint, query.Constraint.Distance):
+            raise NotSupported('Cannot encode distance constraints for (No)Sketch Engine, yet.')
+
+    tokens, global_predicates = associate_predicates(q)
+    alternatives: list[Query] = []
+    for arrangement in arrangements(set(tokens.keys()), q.constraints):
+        alternative = reduce(Sequence, (tokens[i] for i in arrangement))
+        alternatives.append(alternative)
+
+    result = Operator('|', alternatives)
+    if global_predicates or q.dependencies:
+        result = GlobalConstraint(result, global_predicates, set(q.dependencies))
+
+    return add_within_and_anchors(result, q, configuration)
+
+class SketchEngineFormatter(QueryFormatter):
+
+    @classmethod
+    def names(cls) -> Iterable[str]:
+        return TOKEN_ALPHABET
+
+    def format_global_constraint(
+        self, base: str, predicates: list[str], dependencies: list[str]
+    ) -> str:
+        constraint_repr = ' & '.join(predicates + dependencies)
+        return f'({base}) & ({constraint_repr})'
+
+    def format_within_constraint(self, base: str, span: str) -> str:
+        return f'{base} within <{span}/>'
+
+    def format_operator(self, operator: str, queries: list[str]) -> str:
+        return f' {operator} '.join(queries)
+
+    def format_token(
+        self, identifier: query.Identifier, predicates: list[str], dependencies: list[str]
+    ) -> str:
+        prefix = self.environment[identifier] + ':' if identifier in self.environment else ''
+        predicate = ' & '.join(predicates)
+        return f'{prefix}[{predicate}]'
+
+    def format_sequence(self, lhs: str, rhs: str, tokens_between: bool) -> str:
+        if tokens_between:
+            return f'{lhs} []* {rhs}'
+        else:
+            return f'{lhs} {rhs}'
+
+    def format_span(self, span: str, position: query.Position):
+        return f'<{span}>' if position == query.Position.FIRST else f'</{span}>'
+

--- a/src/cqp_tree/translation/cqp.py
+++ b/src/cqp_tree/translation/cqp.py
@@ -1,21 +1,19 @@
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Iterable, Iterator, Optional, override
+from enum import StrEnum
+from typing import Callable, Iterable
 
 from cqp_tree.configuration import Configuration
 from cqp_tree.translation import query
+from cqp_tree.translation.backends.sketch_engine import (
+    SketchEngineFormatter,
+    sketchengine_from_query,
+)
+from cqp_tree.translation.backends.common import Query, QueryFormatter
+from cqp_tree.translation.backends.cwb import CwbFormatter, cwb_from_query
 from cqp_tree.utils import (
-    LOWERCASE_ALPHABET,
     UPPERCASE_ALPHABET,
     associate_with_names,
-    flatmap_set,
-    partition_set,
-    to_str,
 )
 
-Environment = dict[query.Identifier, str]
-
-TOKEN_ALPHABET = LOWERCASE_ALPHABET
 QUERY_ALPHABET = UPPERCASE_ALPHABET
 
 CQP_OPERATIONS = {
@@ -25,329 +23,38 @@ CQP_OPERATIONS = {
 }
 
 
-class Query(ABC):
-    """Abstract base class for all queries."""
-
-    target_identifier: Optional[query.Identifier]
-
-    @abstractmethod
-    def referenced_identifiers(self) -> set[query.Identifier]: ...
-
-    @abstractmethod
-    def format(self, environment: Environment, configuration: Configuration) -> str: ...
-
-    def to_string(self, configuration: Configuration) -> str:
-        environment = associate_with_names(self.referenced_identifiers(), TOKEN_ALPHABET)
-        return self.format(environment, configuration)
+class CQPDialect(StrEnum):
+    CWB = 'Corpus Workbench'
+    SKETCH_ENGINE = 'Sketch Engine'
 
 
-@dataclass
-class Sequence(Query):
-    """Class representing a sequence of queries."""
+TRANSLATORS: dict[CQPDialect, Callable[[query.Query, Configuration], Query]] = {
+    CQPDialect.CWB: cwb_from_query,
+    CQPDialect.SKETCH_ENGINE: sketchengine_from_query,
+}
 
-    lhs: Query
-    rhs: Query
-    tokens_between: bool = True
-
-    @override
-    def referenced_identifiers(self) -> set[query.Identifier]:
-        return self.lhs.referenced_identifiers() | self.rhs.referenced_identifiers()
-
-    @override
-    def format(self, environment: Environment, configuration: Configuration) -> str:
-        def format_subquery(q: Query) -> str:
-            res = q.format(environment, configuration)
-            return f'({res})' if isinstance(q, Operator) else res
-
-        lhs_repr = format_subquery(self.lhs)
-        rhs_repr = format_subquery(self.rhs)
-        if self.tokens_between:
-            return f'{lhs_repr} []* {rhs_repr}'
-        else:
-            return f'{lhs_repr} {rhs_repr}'
-
-
-@dataclass
-class Operator(Query):
-    """Class representing multiple queries joined by some operator (disjunction, for example)."""
-
-    operator: str
-    queries: list[Query]
-
-    @override
-    def referenced_identifiers(self) -> set[query.Identifier]:
-        return flatmap_set(self.queries, lambda q: q.referenced_identifiers())
-
-    @override
-    def format(self, environment: Environment, configuration: Configuration) -> str:
-        parts = []
-        for q in self.queries:
-            if isinstance(q, (Token, Sequence)):
-                parts.append(q.format(environment, configuration))
-            else:
-                parts.append('(' + q.format(environment, configuration) + ')')
-        return f' {self.operator} '.join(parts)
-
-
-@dataclass
-class Token(Query):
-    """Class representing a query for a single token."""
-
-    identifier: query.Identifier
-    # Initialize with empty set by default.
-    associated_predicates: set[query.Predicate] = field(default_factory=set)
-    associated_dependencies: set[query.Dependency] = field(default_factory=set)
-
-    @override
-    def referenced_identifiers(self) -> set[query.Identifier]:
-        identifiers = flatmap_set(
-            self.associated_dependencies, lambda r: r.referenced_identifiers()
-        )
-        identifiers |= flatmap_set(self.associated_predicates, lambda a: a.referenced_identifiers())
-        identifiers -= {self.identifier}
-        return identifiers
-
-    @override
-    def format(self, environment: Environment, configuration: Configuration) -> str:
-        prefix = environment[self.identifier] + ':' if self.identifier in environment else ''
-        predicates = []
-        for attribute in self.associated_predicates:
-            # Expand conjunction as all predicates on token are already conjunct.
-            if isinstance(attribute, query.Conjunction):
-                predicates.extend(format_predicate(p, environment) for p in attribute.predicates)
-            else:
-                predicates.append(format_predicate(attribute, environment))
-
-        for dependency in self.associated_dependencies:
-            if dependency.src == self.identifier:
-                dst = environment[dependency.dst]
-                predicates.append(self._format_dependency(configuration, dst=dst))
-            else:
-                src = environment[dependency.src]
-                predicates.append(self._format_dependency(configuration, src=src))
-
-        predicate = ' & '.join(predicates)
-        return f'{prefix}[{predicate}]'
-
-    @staticmethod
-    def _format_dependency(
-        configuration: Configuration,
-        src: Optional[str] = None,
-        dst: Optional[str] = None,
-    ) -> str:
-        dephead = configuration.dephead
-        ref = configuration.token_id
-        if src is not None and dst is None:
-            return f'{dephead} = {src}.{ref}'
-        if src is None and dst is not None:
-            return f'{dst}.{dephead} = {ref}'
-        raise ValueError('Cannot format when `src´ and `dst´ are None')
-
-
-@dataclass
-class Span(Query):
-    """Class representing begin or end of a text span in the corpus."""
-
-    span: str
-    position: query.Position
-
-    @override
-    def referenced_identifiers(self) -> set[query.Identifier]:
-        return set()
-
-    @override
-    def format(self, environment: Environment, configuration: Configuration) -> str:
-        return f'<{self.span}>' if self.position == query.Position.FIRST else f'</{self.span}>'
-
-
-def format_operand(operand: query.Operand, environment: Environment) -> str:
-    if isinstance(operand, query.Attribute):
-        if operand.reference is not None:
-            return f'{environment[operand.reference]}.{operand.attribute}'
-        return operand.attribute
-    elif isinstance(operand, query.Reference):
-        if operand.reference is not None:
-            return environment[operand.reference]
-        return '_'
-    elif isinstance(operand, query.Function):
-        args = ', '.join(format_operand(arg, environment) for arg in operand.args)
-        return f'{operand.name}({args})'
-    assert isinstance(operand, query.Literal), 'Operand must be either Attribute or Literal.'
-    return operand.value
-
-
-def format_predicate(predicate: query.Predicate, environment: Environment) -> str:
-    if isinstance(predicate, query.Exists):
-        return format_operand(predicate.attribute, environment)
-    elif isinstance(predicate, query.Negation):
-        return f'!{format_predicate(predicate.predicate, environment)}'
-    if isinstance(predicate, query.Comparison):
-        lhs = format_operand(predicate.lhs, environment)
-        rhs = format_operand(predicate.rhs, environment)
-        return f'({lhs} {predicate.operator} {rhs})'
-    else:
-        assert isinstance(predicate, (query.Conjunction, query.Disjunction))
-        operators = {
-            query.Conjunction: '&',
-            query.Disjunction: '|',
-        }
-        predicates = map(lambda p: format_predicate(p, environment), predicate.predicates)
-        return to_str(predicates, '(', f' {operators[type(predicate)]} ', ')')
-
-
-def arrangements(
-    identifiers: set[query.Identifier],
-    constraints: Iterable[query.Constraint],
-) -> Iterator[list[query.Identifier]]:
-    """Arrange a set of Identifiers into all sequences allowed by the given Constraints"""
-    cannot_be_after = {i: set() for i in identifiers}
-    for constraint in constraints:
-        if isinstance(constraint, query.Constraint.Order):
-            fst, snd = constraint
-            cannot_be_after[snd].add(fst)
-        elif isinstance(constraint, query.Constraint.Anchor):
-            (id,) = constraint
-            other_identifiers = identifiers - set(id)
-            if constraint.is_first():  # id cannot be after any of the others
-                cannot_be_after[id].update(other_identifiers)
-            if constraint.is_last():  # No other cannot be after id.
-                for other in other_identifiers:
-                    cannot_be_after[other].add(id)
-
-    # Buffer with space for all identifiers.
-    arrangement: list[query.Identifier | None] = [None] * len(identifiers)
-
-    def arrange(index: int, remaining_identifiers: set[query.Identifier]):
-        if index == len(arrangement):
-            yield list(arrangement)  # Everything is put into an order. Yield it!
-        else:
-            for identifier in remaining_identifiers:
-                arrangement[index] = identifier
-
-                restricted = cannot_be_after[identifier]  # Continue for remaining identifiers.
-                yield from arrange(index + 1, (remaining_identifiers - restricted) - {identifier})
-
-    yield from arrange(0, identifiers)
-
-
-def from_arrangement(
-    arrangement: list[query.Identifier],
-    dependencies: set[query.Dependency],
-    predicates: set[query.Predicate],
-) -> Query:
-    """Build a Query for a sequence of Identifiers."""
-    visited_tokens: set[query.Identifier] = set()
-    remaining_dependencies = dependencies
-    remaining_predicates = predicates
-
-    converted_tokens = [Token(i) for i in arrangement]
-    for token in converted_tokens:
-        visited_tokens.add(token.identifier)
-
-        committable_dependencies, remaining_dependencies = partition_set(
-            remaining_dependencies,
-            lambda rel: rel.referenced_identifiers().issubset(visited_tokens),
-        )
-        committable_predicates, remaining_predicates = partition_set(
-            remaining_predicates,
-            lambda pred: pred.referenced_identifiers().issubset(visited_tokens),
-        )
-
-        token.associated_dependencies.update(committable_dependencies)
-        token.associated_predicates.update(  # Lower predicates when associating with token.
-            p.lower_onto(token.identifier) for p in committable_predicates
-        )
-
-    # Build all tokens into a sequence.
-    res = converted_tokens[0]
-    for index in range(len(arrangement) - 1):
-        res = Sequence(res, converted_tokens[index + 1])
-    return res
-
-
-def from_all_arrangements(
-    identifiers: set[query.Identifier],
-    dependencies: set[query.Dependency],
-    constraints: set[query.Constraint],
-    predicates: set[query.Predicate],
-) -> Query:
-    """Build a query over all sequences of Identifiers."""
-    all_arrangements = [
-        from_arrangement(arrangement, dependencies, predicates)
-        for arrangement in arrangements(identifiers, constraints)
-    ]
-    return Operator('|', all_arrangements)
-
-
-ORDER_TO_OPERATOR = {
-    query.Compare.EQ: '=',
-    query.Compare.NE: '!=',
-    query.Compare.LT: '<',
-    query.Compare.GT: '>',
+FORMATTERS: dict[CQPDialect, type[QueryFormatter]] = {
+    CQPDialect.CWB: CwbFormatter,
+    CQPDialect.SKETCH_ENGINE: SketchEngineFormatter,
 }
 
 
-def distance_to_operand(constraint: query.Constraint.Distance) -> query.Predicate:
-    fst, snd = constraint
-    dist_function = query.Function(
-        'distabs',
-        query.Reference(fst),
-        query.Reference(snd),
-    )
-    distance_literal = query.Literal(str(constraint.distance))
-    return query.Comparison(dist_function, ORDER_TO_OPERATOR[constraint.order], distance_literal)
-
-
-def add_anchors(q: Query, anchors: list[query.Constraint.Anchor], span: str) -> Query:
-    has_last = any(anchor.is_last() for anchor in anchors)
-    if has_last:
-        q = Sequence(q, Span(span, query.Position.LAST), tokens_between=False)
-
-    has_first = any(anchor.is_first() for anchor in anchors)
-    if has_first:
-        q = Sequence(Span(span, query.Position.FIRST), q, tokens_between=False)
-    return q
-
-
 def from_query(q: query.Query, configuration: Configuration) -> Query:
-    """Translate a tree-based query into a CQP query for all different arrangements of tokens."""
-
-    predicates = set(pred.normalize() for pred in q.predicates)
-    anchors: list[query.Constraint.Anchor] = []
-    for constraint in q.constraints:
-        if isinstance(constraint, query.Constraint.Distance):
-            predicates.add(distance_to_operand(constraint))
-        elif isinstance(constraint, query.Constraint.Anchor):
-            anchors.append(constraint)
-
-    for token in q.tokens:  # Raise local predicates to prepare re-ordering.
-        if token.attributes is not None:
-            raised_predicate = token.attributes.raise_from(token.identifier)
-            raised_predicate = raised_predicate.normalize()
-            predicates.add(raised_predicate)
-
-    result = from_all_arrangements(
-        {token.identifier for token in q.tokens},
-        set(q.dependencies),
-        set(q.constraints),
-        predicates,
-    )
-
-    # Add anchors if requested and possible
-    if anchors and configuration.span:
-        result = add_anchors(result, anchors, configuration.span)
-    return result
+    return TRANSLATORS[configuration.dialect](q, configuration)
 
 
-def format_plan(plan: query.Recipe, configuration: Configuration) -> Iterator[str]:
-    within_span_restriction = ''
-    if configuration.span:
-        within_span_restriction = f' within {configuration.span}'
+def format_query(q: Query, configuration: Configuration) -> str:
+    return FORMATTERS[configuration.dialect].to_str(q, configuration)
 
+
+Query.to_string = format_query
+
+
+def format_plan(plan: query.Recipe, configuration: Configuration) -> Iterable[str]:
     environment = associate_with_names(plan.identifiers(), QUERY_ALPHABET)
     parts = plan.as_dict()
 
-    def rec(goal: query.Identifier, include_assignment: bool = True) -> Iterator[str]:
+    def rec(goal: query.Identifier, include_assignment: bool = True) -> Iterable[str]:
         part = parts[goal]
         if isinstance(part, query.Operation):
             op, lhs, rhs = (
@@ -360,7 +67,7 @@ def format_plan(plan: query.Recipe, configuration: Configuration) -> Iterator[st
             yield from rec(part.rhs)
         else:
             query_text = from_query(part, configuration).to_string(configuration)
-            formatted = query_text + within_span_restriction + ';'
+            formatted = query_text + ';'
 
         if include_assignment:
             formatted = f'{environment[goal]} = {formatted}'

--- a/src/cqp_tree/utils.py
+++ b/src/cqp_tree/utils.py
@@ -16,6 +16,7 @@ def filter_is_instance[X, Y](xs: Iterable[X], cls: type[Y]) -> Iterable[Y]:
         if isinstance(x, cls):
             yield x
 
+
 def partition_set[X](s: set[X], predicate: Callable[[X], bool]) -> Tuple[set[X], set[X]]:
     """
     Partitions a set into two sets using the given predicate.

--- a/src/cqp_tree/utils.py
+++ b/src/cqp_tree/utils.py
@@ -11,6 +11,11 @@ def flatmap_set[X, Y](xs: Iterable[X], f: Callable[[X], Iterable[Y]]) -> set[Y]:
     return result
 
 
+def filter_is_instance[X, Y](xs: Iterable[X], cls: type[Y]) -> Iterable[Y]:
+    for x in xs:
+        if isinstance(x, cls):
+            yield x
+
 def partition_set[X](s: set[X], predicate: Callable[[X], bool]) -> Tuple[set[X], set[X]]:
     """
     Partitions a set into two sets using the given predicate.

--- a/tests/test_arrangements.py
+++ b/tests/test_arrangements.py
@@ -1,7 +1,7 @@
 import math
 import unittest
 
-import cqp_tree.translation.cqp as cqp
+import cqp_tree.translation.backends.common as cqp
 import cqp_tree.translation.query as query
 
 


### PR DESCRIPTION
This adds the SketchEngine dialect as one of the potential targets for translation. So far without extensive testing, but it looks good so far!

- Global constraints are now part of the generated abstract syntax (only SketchEngine)
- Within constraints are now part of the generated abstract syntax instead of glue-ing them on afterwards
- If token-level predicates or global constraints are used in a non-supported way, we now produce an error message (only SketchEngine)


Closes #20 