### PR TITLE
Minimal tutorial and citation information

### DIFF
--- a/src/cqp_tree/web/static/about.html
+++ b/src/cqp_tree/web/static/about.html
@@ -44,9 +44,9 @@
                     <a href="https://grew.fr/grew_match/help/">Grew-match</a>,
                     <a href="https://orodja.cjvt.si/drevesnik/help/en/">depsearch</a> and
                     <a href="https://github.com/GrammaticalFramework/deptreepy">deptreepy</a> 
-                    (if you are new to syntactic queries, the 
+                    <!--(if you are new to syntactic queries, the 
                     <a href="https://grew.fr/tutorial/top/">Grew tutorial</a>
-                    is a good place to start).
+                    is a good place to start).-->
                     All three languages prioritize making it easy to search for syntactic relations between tokens. 
                 </p>
 
@@ -54,7 +54,11 @@
                     If you wanted to look for <b>ditransitive predicates</b> in a Universal Dependencies treebank, for instance, you could write the Grew query
 
                     <div class="border rounded bg-light">
-                    <pre>
+                        <button type="button" id="copy-grew" class="btn btn-outline-primary float-end"
+                            data-clipboard-target="#grew" title="Copy to clipboard">
+                            <i class="bi bi-clipboard"></i>
+                        </button> 
+                        <pre id="grew">
 pattern {
     A [upos="VERB"];    % there is a token called "A" whose UPOS tag is "VERB"
     A -[obj]-> B;       % A has a dependent, B, which is labelled as its direct ("obj")
@@ -65,16 +69,30 @@ pattern {
                     In depsearch, you could write the same query as
 
                     <div class="border rounded bg-light">
-                    <pre>
+                        <button type="button" id="copy-depsearch" class="btn btn-outline-primary float-end"
+                            data-clipboard-target="#depsearch" title="Copy to clipboard">
+                            <i class="bi bi-clipboard"></i>
+                        </button> 
+                        <pre id="depsearch">
 VERB >obj _ >iobj _</pre>
                     </div>
 
                     whose deptreepy equivalent is
 
                     <div class="border rounded bg-light">
-                    <pre>
+                        <button type="button" id="copy-deptreepy" class="btn btn-outline-primary float-end"
+                            data-clipboard-target="#deptreepy" title="Copy to clipboard">
+                            <i class="bi bi-clipboard"></i>
+                        </button> 
+                        <pre id="deptreepy">
 TREE_ (POS VERB) (DEPREL obj) (DEPREL iobj)</pre>
                     </div>
+                </p>
+
+                <p>
+                    CQP/Tree can convert all of these syntaxes to CQL and allows you to run them directly on your corpus of choice. 
+                    To get started, try copying and pasting one of the queries above into the 
+                    <a href="..">web interface</a>!
                 </p>
 
                 <h2>
@@ -97,6 +115,9 @@ TREE_ (POS VERB) (DEPREL obj) (DEPREL iobj)</pre>
                     <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
                     <script>
                         new ClipboardJS('#copy-bibtex');
+                        new ClipboardJS('#copy-grew');
+                        new ClipboardJS('#copy-depsearch');
+                        new ClipboardJS('#copy-deptreepy');
                     </script>
                     <div class="border rounded bg-light">
                         <button type="button" id="copy-bibtex" class="btn btn-outline-primary float-end"

--- a/src/cqp_tree/web/static/about.html
+++ b/src/cqp_tree/web/static/about.html
@@ -44,9 +44,6 @@
                     <a href="https://grew.fr/grew_match/help/">Grew-match</a>,
                     <a href="https://orodja.cjvt.si/drevesnik/help/en/">depsearch</a> and
                     <a href="https://github.com/GrammaticalFramework/deptreepy">deptreepy</a> 
-                    <!--(if you are new to syntactic queries, the 
-                    <a href="https://grew.fr/tutorial/top/">Grew tutorial</a>
-                    is a good place to start).-->
                     All three languages prioritize making it easy to search for syntactic relations between tokens. 
                 </p>
 
@@ -93,6 +90,17 @@ TREE_ (POS VERB) (DEPREL obj) (DEPREL iobj)</pre>
                     CQP/Tree can convert all of these syntaxes to CQL and allows you to run them directly on your corpus of choice. 
                     To get started, try copying and pasting one of the queries above into the 
                     <a href="..">web interface</a>!
+                </p>
+                
+                <p>
+                    For some more advanced examples,  
+                    {% if cfg.system_name == "CLARIN.SI noSketch Engine"%}
+                    follow <a href="https://somewhere.xyz">this link</a>.
+                    {% elif cfg.system_name == "Språkbanken's Korp"%}
+                    follow <a href="https://spraakbanken.gu.se/blogg/a-blog-post-that-has-not-been-written-yet">this link</a>.
+                    {% else %}
+                    check out the <a href="https://grew.fr/tutorial/top/">Grew tutorial</a>.
+                    {% endif %}
                 </p>
 
                 <h2>

--- a/src/cqp_tree/web/static/about.html
+++ b/src/cqp_tree/web/static/about.html
@@ -52,8 +52,40 @@
                 <p>
                     Translated queries may differ from native syntactic search tools in terms of precision and recall,
                     especially for complex multi-token queries. For details on the translation approach, evaluation and
-                    known limitations, see the
-                    <a href="https://lrec.elra.info/lrec2026-main-914">accompanying paper</a>.
+                    known limitations, see Section 7 of the
+                    <a href="https://doi.org/10.63317/2vfu2ssa33us">accompanying paper</a>.
+                </p>
+
+                <h2>
+                    How to cite
+                </h2>
+                <p>
+                    If you use CQP/Tree in your research, you are welcome to cite
+                    <a href="https://doi.org/10.63317/2vfu2ssa33us">Niklas Deworetzki and Arianna Masciolini. <i>Syntactic Sugar for Syntactic Queries: Sequential Representations for Dependency Queries</i>. In Proceedings of the Fifteenth Language Resources and Evaluation Conference (LREC 2026)</a>:
+                    
+                    <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
+                    <script>
+                        new ClipboardJS('#copy-bibtex');
+                    </script>
+                    <div class="border rounded bg-light">
+                        <button type="button" id="copy-bibtex" class="btn btn-outline-primary float-end"
+                            data-clipboard-target="#bibtex" title="Copy to clipboard">
+                            <i class="bi bi-clipboard"></i>
+                        </button> 
+                        <pre id="bibtex">
+@inproceedings{deworetzki-etal-2026-syntactic,
+    title = {Syntactic Sugar for Syntactic Queries: Sequential Representations for Dependency Queries},
+    author = {Deworetzki, Niklas and Masciolini, Arianna},
+    booktitle = {Proceedings of the Fifteenth Language Resources and Evaluation Conference ({LREC} 2026)},
+    month = {May},
+    year = {2026},
+    pages = {11669--11678},
+    address = {Palma, Mallorca, Spain},
+    publisher = {European Language Resources Association (ELRA)},
+    editor = {Piperidis, Stelios and Bel, Núria and van den Heuvel, Henk and Ide, Nancy and Krek, Simon and Toral, Antonio},
+    doi = {10.63317/2vfu2ssa33us},
+}</pre>
+                    </div>
                 </p>
 
                 <h2>

--- a/src/cqp_tree/web/static/about.html
+++ b/src/cqp_tree/web/static/about.html
@@ -23,10 +23,10 @@
             <div>
 
                 <h1 class="my-5">CQP/Tree</h1>
-                <h2>Convert syntactic tree queries into CQL</h2>
+                <h2>What is CQP/Tree?</h2>
 
                 <p>
-                    CQP/Tree converts readable syntactic tree queries into CQL for use in Sketch Engine, Korp, Corpus
+                    CQP/Tree converts human-readable syntactic tree queries into CQL for use in Sketch Engine, Korp, Corpus
                     Workbench and related corpus search systems. This installation is primarily intended to support
                     syntactic searching in
                     {% if cfg.homepage %}
@@ -38,12 +38,43 @@
                     Workbench-compatible corpora and platforms.
                 </p>
 
+                <h2>Getting started</h2>
                 <p>
-                    If you are new to syntactic tree querying, you may want to start with the example queries below or
-                    consult the documentation for the supported input languages, such as
-                    <a href="https://orodja.cjvt.si/drevesnik/help/en/">depsearch</a>
-                    or
-                    <a href="https://universal.grew.fr/?corpus=UD_English-ParTUT@2.18">Grew</a>.
+                    CQP/Tree supports three main input languages:
+                    <a href="https://grew.fr/grew_match/help/">Grew-match</a>,
+                    <a href="https://orodja.cjvt.si/drevesnik/help/en/">depsearch</a> and
+                    <a href="https://github.com/GrammaticalFramework/deptreepy">deptreepy</a> 
+                    (if you are new to syntactic queries, the 
+                    <a href="https://grew.fr/tutorial/top/">Grew tutorial</a>
+                    is a good place to start).
+                    All three languages prioritize making it easy to search for syntactic relations between tokens. 
+                </p>
+
+                <p>
+                    If you wanted to look for <b>ditransitive predicates</b> in a Universal Dependencies treebank, for instance, you could write the Grew query
+
+                    <div class="border rounded bg-light">
+                    <pre>
+pattern {
+    A [upos="VERB"];    % there is a token called "A" whose UPOS tag is "VERB"
+    A -[obj]-> B;       % A has a dependent, B, which is labelled as its direct ("obj")
+    A -[iobj]-> C       % A also has another dependent, C, labelled as indirect object ("iobj")
+}</pre>
+                    </div>
+
+                    In depsearch, you could write the same query as
+
+                    <div class="border rounded bg-light">
+                    <pre>
+VERB >obj _ >iobj _</pre>
+                    </div>
+
+                    whose deptreepy equivalent is
+
+                    <div class="border rounded bg-light">
+                    <pre>
+TREE_ (POS VERB) (DEPREL obj) (DEPREL iobj)</pre>
+                    </div>
                 </p>
 
                 <h2>


### PR DESCRIPTION
I gave #29 some more thought and, for now, only added the about page a very minimal tutorial (only one "universal" examples + links to language docs), as well as more prominent citation information.
At the end of this mini-tutorial, there is a paragraph that says "For some more advanced examples, follow __this link__", where "this link" redirects to different places depending on `cfg.system_name`, namely (I propose):

1. Korp: a post yet to be written on the Språkbanken's blog (nice side effect: I don't have to write a _separate_ blog post about the research visit ;)
2. CLARIN.SI: whatever @kajad prefers! It can be both a separate internal page or something like 1.
3. no particular config: the step-by-step Grew tutorial

Thoughts?