### PR TITLE
Minor tweaks

### DIFF
--- a/configurations/spraakbanken-korp/server.toml
+++ b/configurations/spraakbanken-korp/server.toml
@@ -2,5 +2,5 @@
 branding = "https://spraakbanken.gu.se/korp/574c266f2118886f71f7.svg"
 homepage = "https://spraakbanken.gu.se/"
 baseurl = "https://spraakbanken.gu.se/korp/#?search_tab=2&search=cqp%7C{query}"
-system_name = "Språkbankens Korp"
+system_name = "Språkbanken's Korp"
 corpus_configs = "configurations/spraakbanken-korp/corpora"

--- a/src/cqp_tree/web/static/index.html
+++ b/src/cqp_tree/web/static/index.html
@@ -45,7 +45,12 @@
                                 CQP/Tree
                             </span>
                             <span class="fs-6 text-muted d-block">
-                                Syntactic queries for {{ cfg.system_name }}
+                                Syntactic queries for 
+                                {% if cfg.system_name != "corpus"%} 
+                                {{ cfg.system_name }} 
+                                {% else %}
+                                large-scale corpora
+                                {% endif %}
                             </span>
                         </div>
 


### PR DESCRIPTION
This pull request just changes a couple strings:

- "Språkbankens Korp" $\to$ "Språkbanken's Korp"
- "Syntactic queries for corpus" $\to$ "Syntactic queries for large-scale corpora" when the corpus system is unspecified